### PR TITLE
Allow dr to run on machines with only .net 4.0+ installed.

### DIFF
--- a/Dark Room W/app.config
+++ b/Dark Room W/app.config
@@ -8,6 +8,10 @@
             <section name="DarkRoomW.Properties.Settings" type="System.Configuration.ClientSettingsSection, System, Version=2.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089" requirePermission="false" />
         </sectionGroup>
     </configSections>
+	<startup>
+		<supportedRuntime version="v2.0.50727"/>
+		<supportedRuntime version="v4.0" />
+	</startup>
     <userSettings>
         <DarkRoomW.Properties.Settings>
             <setting name="PageColor" serializeAs="String">

--- a/Dark Room W/frmMain.cs
+++ b/Dark Room W/frmMain.cs
@@ -481,7 +481,7 @@ namespace DarkRoomW
             txtPage.Modified = false;
 
             dlgOpen.Filter = "Text Documents (*.txt)|*.txt|All files (*.*)|*.*";
-            dlgSave.Filter = "Text Documents (*.txt)|*.txt";
+            dlgSave.Filter = "Text Documents (*.txt)|*.txt|All files (*.*)|*.*";
 
             if (txtPage.FormattingEnabled)
             {


### PR DESCRIPTION
I added a &lt;startup&gt; element to the app.config for newer machines without 2.0/3.5 installed. 

According to [msdn](http://msdn.microsoft.com/en-us/library/jj152935.aspx), the supportedruntime elements added in this order will first try to use .net 2.0/3.5 if installed, and fallback gracefully into .net 4.0/4.5 if that is installed.

I had to do this to get dr running, and it does work as expected.

I also added the All files filter to the save dialog, just in case the format to save is not .txt/.rtf.
